### PR TITLE
Use stdin for input when no file or url is given

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,6 +19,6 @@
       qrep.file(argv[2], argv[3], encoding);
     }
   } else {
-    console.log('See qrep usage');
+    qrep.stream(argv[2], process.stdin, encoding);
   }
 }());

--- a/lib/qrep.js
+++ b/lib/qrep.js
@@ -1,4 +1,5 @@
-module.exports.file  = require('./file');
-module.exports.url   = require('./url');
-module.exports.usage = require('./usage');
+module.exports.file   = require('./file');
+module.exports.url    = require('./url');
+module.exports.stream = require('./stream');
+module.exports.usage  = require('./usage');
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,0 +1,21 @@
+module.exports = function (selectors, stream, encoding) {
+  var jsdom = require("jsdom");
+  var fs = require("fs");
+
+  stream.resume();
+  stream.setEncoding(encoding);
+
+  var html = "";
+  stream.on("data", function (chunk) {
+    html += chunk;
+  });
+  stream.on("end", function () {
+    jsdom.env(html, function (err, window) {
+      var parent = window.document;
+      var node = parent.querySelectorAll(selectors);
+      for (var i = 0; node.length > i; i++) {
+        console.log(node[i].outerHTML);
+      }
+    });
+  });
+};


### PR DESCRIPTION
I think it's better to use STDIN when no file or url is specified to cli to be more compatible with `grep` command.

Maybe some refactoring is needed though...
### Example

```
$ curl -s -L "http://google.com/" | qrep title
<title>Google</title>
```
